### PR TITLE
PMC-162 Viewer changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pmc-viewer",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Canvas panel driven viewing experience for PMC project",
   "files": [
     "lib",

--- a/src/App.js
+++ b/src/App.js
@@ -6,10 +6,14 @@ import Layout from './components/Layout/Layout';
 import Viewer from './components/Viewer/Viewer';
 import { connect } from 'react-redux';
 import Theme from './components/Theme/Theme';
+import { search } from '@canvas-panel/search';
+import { waitAndSearch } from './createStore';
 
 class App extends Component {
   viewport = null;
   state = { viewportAvailable: false };
+
+  static defaultProps = { searchQuery: null };
 
   setViewport = viewport => {
     this.viewport = viewport;
@@ -23,6 +27,18 @@ class App extends Component {
           this.props.startCanvas === 0 ? 0 : this.props.startCanvas || 2,
       })
     );
+  }
+
+  componentWillMount() {
+    if (this.props.initialSearch) {
+      waitAndSearch(this.props.store, this.props.initialSearch);
+    }
+  }
+
+  componentWillReceiveProps(newProps, newContext) {
+    if (newProps.searchQuery !== this.props.searchQuery) {
+      waitAndSearch(this.props.store, newProps.searchQuery);
+    }
   }
 
   handleClickAnnotation = anno => {

--- a/src/components/PmcViewerComponent/PmcViewerComponent.js
+++ b/src/components/PmcViewerComponent/PmcViewerComponent.js
@@ -12,6 +12,12 @@ class PmcViewerPopOutComponent extends Component {
 
   close = () => this.setState({ isOpen: false });
 
+  componentWillMount() {
+    if (this.props.registerOpener) {
+      this.props.registerOpener(this.open);
+    }
+  }
+
   render() {
     const { isOpen } = this.state;
     const { text, bem, ...props } = this.props;

--- a/src/components/PmcViewerComponent/PmcViewerComponent.scss
+++ b/src/components/PmcViewerComponent/PmcViewerComponent.scss
@@ -34,18 +34,18 @@
         pointer-events: visible;
       }
     }
-  }
 
-  @media (min-width: 1025px) and (max-width: 1280px) {
-    //CSS
-    .layout__header {
-      transform: translateY(-100px);
-      transition: transform 0.3s;
-    }
-    &--isOpen {
+    @media (min-width: 1025px) and (max-width: 1280px) {
+      //CSS
       .layout__header {
-        pointer-events: visible;
-        transform: translateY(0);
+        transform: translateY(-100px);
+        transition: transform 0.3s;
+      }
+      &--isOpen {
+        .layout__header {
+          pointer-events: visible;
+          transform: translateY(0);
+        }
       }
     }
   }

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -5,9 +5,13 @@ import {
 } from '@canvas-panel/search';
 import { search } from '@canvas-panel/search';
 
-function addInitialSearch(store, q) {
+export function waitAndSearch(store, q) {
   if (!q) {
     return;
+  }
+  const state = store.getState();
+  if (state && state.search && state.search.service) {
+    store.dispatch(search.searchRequest({ q }));
   }
   const unsubscribe = store.subscribe(() => {
     if (store.getState().search.service) {
@@ -17,16 +21,12 @@ function addInitialSearch(store, q) {
   });
 }
 
-export default function createCustomStore({ initialSearch } = {}) {
-  const store = createStore(
+export default function createCustomStore() {
+  return createStore(
     {
       search: searchReducer,
     },
     [],
     [searchSaga]
   );
-
-  addInitialSearch(store, initialSearch);
-
-  return store;
 }

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -3,13 +3,30 @@ import {
   reducer as searchReducer,
   saga as searchSaga,
 } from '@canvas-panel/search';
+import { search } from '@canvas-panel/search';
 
-export default function createCustomStore() {
-  return createStore(
+function addInitialSearch(store, q) {
+  if (!q) {
+    return;
+  }
+  const unsubscribe = store.subscribe(() => {
+    if (store.getState().search.service) {
+      unsubscribe();
+      store.dispatch(search.searchRequest({ q }));
+    }
+  });
+}
+
+export default function createCustomStore({ initialSearch } = {}) {
+  const store = createStore(
     {
       search: searchReducer,
     },
     [],
     [searchSaga]
   );
+
+  addInitialSearch(store, initialSearch);
+
+  return store;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,9 @@ function createPmcViewerComponent($viewer) {
   const initialProps = { ...$viewer.dataset };
   const innerText = $viewer.innerText;
   const store = getStoreFromCache(initialProps.manifest);
+  const registerOpener = open => {
+    $viewer.open = open;
+  };
 
   render(
     <ObservableElement
@@ -43,6 +46,7 @@ function createPmcViewerComponent($viewer) {
               {...props}
               store={store}
               text={innerText}
+              registerOpener={registerOpener}
               getRef={osd => ($viewer.osd = osd)}
             />
           </Provider>

--- a/src/index.js
+++ b/src/index.js
@@ -12,11 +12,11 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 const storeCache = {};
-function getStoreFromCache(manifestId) {
-  if (!storeCache[manifestId]) {
-    storeCache[manifestId] = createStore();
+function getStoreFromCache(manifestId, initialSearch) {
+  if (!storeCache[manifestId + initialSearch]) {
+    storeCache[manifestId + initialSearch] = createStore({ initialSearch });
   }
-  return storeCache[manifestId];
+  return storeCache[manifestId + initialSearch];
 }
 
 function isValidElement($el) {
@@ -30,7 +30,10 @@ function createPmcViewerComponent($viewer) {
   }
   const initialProps = { ...$viewer.dataset };
   const innerText = $viewer.innerText;
-  const store = getStoreFromCache(initialProps.manifest);
+  const store = getStoreFromCache(
+    initialProps.manifest,
+    initialProps.initialSearch || null
+  );
 
   render(
     <ObservableElement
@@ -74,11 +77,12 @@ document.addEventListener('DOMContentLoaded', () => {
       return null;
     }
     const manifest = $viewer.getAttribute('data-manifest');
-    const store = getStoreFromCache(manifest);
+    const initialSearch = $viewer.getAttribute('data-initial-search') || null;
+    const store = getStoreFromCache(manifest, initialSearch);
 
     render(
       <Provider store={store}>
-        <App manifest={$viewer.getAttribute('data-manifest')} />
+        <App {...$viewer.dataset} />
       </Provider>,
       $viewer
     );

--- a/src/views/01-examples/index.md
+++ b/src/views/01-examples/index.md
@@ -29,4 +29,3 @@ name: Examples index page
         line-height: 80px;
     }
 </style>
--->

--- a/src/views/01-examples/index.md
+++ b/src/views/01-examples/index.md
@@ -4,6 +4,7 @@ name: Examples index page
 
 <div data-element="pmc-viewer"
      data-manifest="https://wellcomelibrary.org/iiif/b18035723/manifest"
+     data-initial-search="wunder"
      style="width: 600px;height: 700px; max-width: 100%"
 >
 </div>
@@ -14,6 +15,7 @@ name: Examples index page
      data-manifest="https://wellcomelibrary.org/iiif/b18035723/manifest">
     Wunder der Vererbung
 </div>
+
 <div data-css-class-map='{"pmc-title": "custom-pmc-title"}'
      data-element="pmc-viewer-pop-out"
      data-manifest="https://wellcomelibrary.org/iiif/b21213483/manifest">
@@ -27,3 +29,4 @@ name: Examples index page
         line-height: 80px;
     }
 </style>
+-->


### PR DESCRIPTION
* Search can now be part of the initial props
* Search can be changed on the fly using `$elm.setAttribute('data-search-query', 'something to search')`
* Both pop out and normal viewer are observable
* Fixed responsive aspects of header
* Waits for search service to be available before performing search
* Added `$elem.open();` API to pop-up component